### PR TITLE
Password popup, preshared key and dns option, some bug fixes

### DIFF
--- a/clickable.json
+++ b/clickable.json
@@ -1,5 +1,5 @@
 {
-  "clickable_minimum_required": "6.22.0",
   "builder": "cmake",
-  "kill": "qmlscene"
+  "kill": "qmlscene",
+  "clickable_minimum_required": "7"
 }

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -3,11 +3,14 @@ import QtQuick.Layouts 1.3
 import Qt.labs.settings 1.0
 import io.thp.pyotherside 1.3
 import Ubuntu.Components 1.3 as UITK
+import Ubuntu.Components.Popups 1.3
 
 import "./pages"
 import "./components"
 
 UITK.MainView {
+    property string pwd
+
     id: root
     objectName: 'mainView'
     applicationName: 'wireguard.davidv.dev'
@@ -30,11 +33,51 @@ UITK.MainView {
         id: stack
     }
 
-    Component.onCompleted: {
-        if (settings.finishedWizard) {
-            stack.push(Qt.resolvedUrl("pages/PickProfilePage.qml"))
-        } else {
-            stack.push(Qt.resolvedUrl("pages/WizardPage.qml"))
+    Component {
+        id: passwordPopup
+        Dialog {
+            id: passwordDialog
+            title: i18n.tr("Enter password")
+            text: i18n.tr("Your password is required for this action:")
+
+            signal accepted(string password)
+            signal rejected()
+
+            UITK.TextField {
+                id: passwordTextField
+                echoMode: TextInput.Password
+            }
+            UITK.Button {
+                text: i18n.tr("OK")
+                color: UITK.UbuntuColors.green
+                onClicked: {
+                    passwordDialog.accepted(passwordTextField.text)
+                    PopupUtils.close(passwordDialog)
+                }
+            }
+            UITK.Button {
+                text: i18n.tr("Cancel")
+                onClicked: {
+                    passwordDialog.rejected();
+                    PopupUtils.close(passwordDialog)
+                }
+            }
         }
+    }
+
+    Component.onCompleted: {
+        var popup = PopupUtils.open(passwordPopup)
+        popup.accepted.connect(function(password) {
+            root.pwd = password;
+
+            if (settings.finishedWizard) {
+                stack.push(Qt.resolvedUrl("pages/PickProfilePage.qml"))
+            } else {
+                stack.push(Qt.resolvedUrl("pages/WizardPage.qml"))
+            }
+        })
+        popup.rejected.connect(function() {
+            console.log("canceled!");
+        })
     }
 }

--- a/qml/pages/PickProfilePage.qml
+++ b/qml/pages/PickProfilePage.qml
@@ -172,6 +172,7 @@ UITK.Page {
                             }
 
                             Text {
+                                color: theme.palette.normal.foregroundText
                                 text: toHuman(c_status.peers[index].rx)
                             }
                             UITK.Icon {
@@ -181,9 +182,11 @@ UITK.Page {
                                 color: 'green'
                             }
                             Text {
+                                color: theme.palette.normal.foregroundText
                                 text: toHuman(c_status.peers[index].tx)
                             }
                             Text {
+                                color: theme.palette.normal.foregroundText
                                 text: ' - ' + ago(
                                           c_status.peers[index].latest_handshake)
                             }

--- a/qml/pages/PickProfilePage.qml
+++ b/qml/pages/PickProfilePage.qml
@@ -99,6 +99,7 @@ UITK.Page {
                                            "ipAddress": ip_address,
                                            "privateKey": private_key,
                                            "extraRoutes": extra_routes,
+                                           "dnsServers": dns_servers,
                                            "interfaceName": interface_name.length == 0 ? "wg" + index : interface_name
                                        })
                         }

--- a/qml/pages/PickProfilePage.qml
+++ b/qml/pages/PickProfilePage.qml
@@ -9,6 +9,7 @@ import "../components"
 UITK.Page {
     Settings {
         id: settings
+        property bool useUserspace: true
     }
     header: UITK.PageHeader {
         id: header
@@ -46,8 +47,7 @@ UITK.Page {
             onClicked: {
                 if (!c_status.init) {
                     python.call('vpn.instance._connect',
-                                [profile_name, !settings.value('useUserspace',
-                                                               true)],
+                                [profile_name, !settings.useUserspace],
                                 function (error_msg) {
                                     if (error_msg) {
                                         toast.show('Failed:' + error_msg)

--- a/qml/pages/PickProfilePage.qml
+++ b/qml/pages/PickProfilePage.qml
@@ -18,7 +18,8 @@ UITK.Page {
             UITK.Action {
                 iconName: "add"
                 onTriggered: {
-                    stack.push(Qt.resolvedUrl("ProfilePage.qml"))
+                    stack.push(Qt.resolvedUrl("ProfilePage.qml"),
+                               {interfaceName: "wg" + listmodel.count})
                 }
             },
             UITK.Action {
@@ -76,7 +77,7 @@ UITK.Page {
                                            "ipAddress": ip_address,
                                            "privateKey": private_key,
                                            "extraRoutes": extra_routes,
-                                           "interfaceName": interface_name
+                                           "interfaceName": interface_name.length == 0 ? "wg" + index : interface_name
                                        })
                         }
                     }

--- a/qml/pages/PickProfilePage.qml
+++ b/qml/pages/PickProfilePage.qml
@@ -65,6 +65,28 @@ UITK.Page {
                 }
             }
 
+            leadingActions: UITK.ListItemActions {
+                actions: [
+                    UITK.Action {
+                        iconName: 'delete'
+                        onTriggered: {
+                            python.call('vpn.instance.delete_profile', [profile_name],
+                                        function (error) {
+                                            if (error) {
+                                                console.log(error)
+                                                toast.show('Failed:' + error)
+                                            }
+                                            else
+                                            {
+                                                toast.show('Profile '+ profile_name +' deleted');
+                                                listmodel.remove(index);
+                                            }
+                                        })
+                        }
+                    }
+                ]
+            }
+
             trailingActions: UITK.ListItemActions {
                 actions: [
                     UITK.Action {

--- a/qml/pages/PickProfilePage.qml
+++ b/qml/pages/PickProfilePage.qml
@@ -45,7 +45,7 @@ UITK.Page {
             height: col.height + col.anchors.topMargin + col.anchors.bottomMargin
             onClicked: {
                 if (!c_status.init) {
-                    python.call('vpn._connect',
+                    python.call('vpn.instance._connect',
                                 [profile_name, !settings.value('useUserspace',
                                                                true)],
                                 function (error_msg) {
@@ -57,7 +57,7 @@ UITK.Page {
                                     showStatus()
                                 })
                 } else {
-                    python.call('vpn.interface.disconnect', [interface_name],
+                    python.call('vpn.instance.interface.disconnect', [interface_name],
                                 function () {
                                     toast.show("Disconnected")
                                 })
@@ -176,7 +176,8 @@ UITK.Page {
         interval: 1000
         running: true
         onTriggered: {
-            showStatus()
+            if(listmodel.count > 0)
+                showStatus();
         }
     }
 
@@ -220,7 +221,7 @@ UITK.Page {
     }
 
     function populateProfiles() {
-        python.call('vpn.list_profiles', [], function (profiles) {
+        python.call('vpn.instance.list_profiles', [], function (profiles) {
             listmodel.clear()
             for (var i = 0; i < profiles.length; i++) {
                 profiles[i].init = false
@@ -229,7 +230,7 @@ UITK.Page {
         })
     }
     function showStatus() {
-        python.call('vpn.interface.current_status_by_interface', [],
+        python.call('vpn.instance.interface.current_status_by_interface', [],
                     function (all_status) {
                         const keys = Object.keys(all_status)
                         for (var i = 0; i < listmodel.count; i++) {
@@ -257,8 +258,10 @@ UITK.Page {
         Component.onCompleted: {
             addImportPath(Qt.resolvedUrl('../../src/'))
             importModule('vpn', function () {
-                populateProfiles()
-                showStatus()
+                python.call('vpn.instance.set_pwd', [root.pwd], function(result){});
+                populateProfiles();
+                if(listmodel.count > 0)
+                    showStatus();
             })
         }
     }

--- a/qml/pages/ProfilePage.qml
+++ b/qml/pages/ProfilePage.qml
@@ -176,6 +176,16 @@ UITK.Page {
                         }
                         placeholder: "vpn.example.com:1234"
                     }
+
+                    MyTextField {
+                        title: i18n.tr("Preshared key")
+                        placeholder: "c29tZSBzaWxseSBzdHVmZgo="
+                        text: presharedKey
+                        onChanged: {
+                            errorMsg = ''
+                            presharedKey = text
+                        }
+                    }
                 }
             }
 
@@ -190,7 +200,8 @@ UITK.Page {
                                          "name": '',
                                          "key": '',
                                          "allowedPrefixes": '',
-                                         "endpoint": ''
+                                         "endpoint": '',
+                                         "presharedKey": ''
                                      })
                 }
             }
@@ -224,7 +235,8 @@ UITK.Page {
                                         "name": p.name,
                                         "key": p.key,
                                         "allowed_prefixes": p.allowedPrefixes,
-                                        "endpoint": p.endpoint
+                                        "endpoint": p.endpoint,
+                                        "presharedKey": p.presharedKey
                                     })
                     }
 
@@ -256,7 +268,8 @@ UITK.Page {
                                  "name": p.name,
                                  "key": p.key,
                                  "allowedPrefixes": p.allowed_prefixes,
-                                 "endpoint": p.endpoint
+                                 "endpoint": p.endpoint,
+                                 "presharedKey": p.presharedKey
                              })
         }
     }

--- a/qml/pages/ProfilePage.qml
+++ b/qml/pages/ProfilePage.qml
@@ -72,7 +72,7 @@ UITK.Page {
                             id: genKey
                             text: i18n.tr("Generate")
                             onClicked: {
-                                privateKey = python.call_sync('vpn.genkey', [])
+                                privateKey = python.call_sync('vpn.instance.genkey', [])
                             }
                         }
                         UITK.Button {
@@ -80,7 +80,7 @@ UITK.Page {
                             enabled: privateKey
                             onClicked: {
                                 const pubkey = python.call_sync(
-                                                 'vpn.genpubkey', [privateKey])
+                                                 'vpn.instance.genpubkey', [privateKey])
                                 UITK.Clipboard.push(pubkey)
                                 toast.show('Public key copied to clipboard')
                             }
@@ -228,7 +228,7 @@ UITK.Page {
                                     })
                     }
 
-                    python.call('vpn.save_profile',
+                    python.call('vpn.instance.save_profile',
                                 [profileName, ipAddress, privateKey, interfaceName, extraRoutes, _peers],
                                 function (error) {
                                     console.log(error)
@@ -265,7 +265,9 @@ UITK.Page {
         id: python
         Component.onCompleted: {
             addImportPath(Qt.resolvedUrl('../../src/'))
-            importModule('vpn', function () {})
+            importModule('vpn', function () {
+                python.call('vpn.instance.set_pwd', [root.pwd], function(result){});
+            })
         }
     }
 }

--- a/qml/pages/ProfilePage.qml
+++ b/qml/pages/ProfilePage.qml
@@ -13,6 +13,7 @@ UITK.Page {
     property string ipAddress
     property string privateKey
     property string extraRoutes
+    property string dnsServers
     property string interfaceName
 
     property variant peers: []
@@ -104,6 +105,15 @@ UITK.Page {
                     onChanged: {
                         errorMsg = ''
                         extraRoutes = text
+                    }
+                }
+                MyTextField {
+                    title: i18n.tr("DNS")
+                    text: dnsServers
+                    placeholder: "10.0.0.1"
+                    onChanged: {
+                        errorMsg = ''
+                        dnsServers = text
                     }
                 }
             }
@@ -241,7 +251,7 @@ UITK.Page {
                     }
 
                     python.call('vpn.instance.save_profile',
-                                [profileName, ipAddress, privateKey, interfaceName, extraRoutes, _peers],
+                                [profileName, ipAddress, privateKey, interfaceName, extraRoutes, dnsServers, _peers],
                                 function (error) {
                                     if (!error) {
                                         if (!isEditing) {

--- a/qml/pages/ProfilePage.qml
+++ b/qml/pages/ProfilePage.qml
@@ -243,7 +243,6 @@ UITK.Page {
                     python.call('vpn.instance.save_profile',
                                 [profileName, ipAddress, privateKey, interfaceName, extraRoutes, _peers],
                                 function (error) {
-                                    console.log(error)
                                     if (!error) {
                                         if (!isEditing) {
                                             settings.interfaceNumber = settings.interfaceNumber + 1
@@ -252,8 +251,10 @@ UITK.Page {
                                         stack.push(Qt.resolvedUrl(
                                                        "PickProfilePage.qml"))
                                         return
+                                    } else {
+                                        console.log(error);
+                                        errorMsg = error;
                                     }
-                                    errorMsg = error
                                 })
                 }
             }

--- a/qml/pages/SettingsPage.qml
+++ b/qml/pages/SettingsPage.qml
@@ -15,6 +15,18 @@ UITK.Page {
     header: UITK.PageHeader {
         id: header
         title: "Settings"
+
+        leadingActionBar.actions: [
+            UITK.Action {
+                iconName: "back"
+                onTriggered: {
+                    // In case of useUserspace property changed,
+                    // make sure PickProfilePage gets loaded new, so the settings object gets also refreshed
+                    stack.clear()
+                    stack.push(Qt.resolvedUrl("PickProfilePage.qml"))
+                }
+            }
+        ]
     }
     ListView {
         anchors.top: header.bottom

--- a/qml/pages/WizardPage.qml
+++ b/qml/pages/WizardPage.qml
@@ -71,13 +71,16 @@ for an example change to the kernel."
         property bool useUserspace: true
         property bool canUseKmod: false
     }
+
     Python {
         id: python
         Component.onCompleted: {
             addImportPath(Qt.resolvedUrl('../../src/'))
             importModule('vpn', function () {
-                python.call('vpn.can_use_kernel_module', [],
+                python.call('vpn.instance.set_pwd', [root.pwd], function(result){});
+                python.call('vpn.instance.can_use_kernel_module', [],
                             function (can_use_module) {
+                                console.debug("can use kernel module::"+can_use_module);
                                 settings.canUseKmod = can_use_module
                                 settings.useUserspace = !can_use_module
                                 wizardRunning = false

--- a/src/interface.py
+++ b/src/interface.py
@@ -6,118 +6,146 @@ from pathlib import Path
 WG_PATH = Path(os.getcwd()) / "vendored/wg"
 log = logging.getLogger(__name__)
 
-def _connect(profile, config_file, use_kmod):
-    interface_name = profile['interface_name']
-    disconnect(interface_name)
+class Interface:
+    def __init__(self, sudo_pwd):
+        # sudo_cmd_list variable is a list like: ['echo', 'password', '|', '/usr/bin/sudo', '-S']
+        self._sudo_pwd = sudo_pwd
 
-    if use_kmod:
-        subprocess.run(['sudo', 'ip', 'link', 'add', interface_name, 'type', 'wireguard'], check=True)
-        config_interface(profile, config_file)
-    else:
-        start_daemon(profile, config_file)
+    def serve_sudo_pwd(self):
+        return subprocess.Popen(['echo', self._sudo_pwd], stdout=subprocess.PIPE)
 
+    def _connect(self, profile, config_file, use_kmod):
+        interface_name = profile['interface_name']
+        self.disconnect(interface_name)
 
-def start_daemon(profile, config_file):
-    p = subprocess.Popen(['/usr/bin/python3', 'src/daemon.py', profile['profile_name']],
-                          stdout=subprocess.PIPE,
-                          stderr=subprocess.PIPE,
-                          stdin=subprocess.DEVNULL,
-                          start_new_session=True,
-                        )
-    print('started daemon')
-
-def config_interface(profile, config_file):
-    interface_name = profile['interface_name']
-    log.info('Configuring interface %s', interface_name)
-    subprocess.run(['/usr/bin/sudo', 'ip', 'link', 'set', 'down', 'dev', interface_name], check=False)
-    log.info('Interface down')
-
-    p = subprocess.Popen(['/usr/bin/sudo', str(WG_PATH),
-                          'setconf', interface_name, str(config_file)],
-                          stdout=subprocess.PIPE,
-                          stderr=subprocess.PIPE,
-                          )
-    p.wait()
-    log.info('Interface %s configured with %s', interface_name, config_file)
-    err = p.stderr.read().decode()
-    if p.returncode != 0:
-        log.error('But failed!')
-        log.error(p.stdout.read().decode())
-        log.error(err.strip())
-        return err
-
-    log.info('Successfully')
-    # TODO: check return codes
-    subprocess.run(['/usr/bin/sudo', 'ip', 'address', 'add', 'dev', interface_name, profile['ip_address']], check=True)
-    log.info('Address set')
-    subprocess.run(['/usr/bin/sudo', 'ip', 'link', 'set', 'up', 'dev', interface_name], check=True)
-    log.info('Interface up')
-
-    for extra_route in profile['extra_routes'].split(','):
-        extra_route = extra_route.strip()
-        if not extra_route:
-            continue
-        subprocess.run(['/usr/bin/sudo', 'ip', 'route', 'add', extra_route, 'dev', interface_name], check=True)
-
-def disconnect(interface_name):
-    # It is fine to have this fail, it is only trying to cleanup before starting
-    subprocess.run(['/usr/bin/sudo', 'ip', 'link', 'del', 'dev', interface_name],
-                   stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
-                   check=False)
-
-def _get_wg_status():
-    if Path('/usr/bin/sudo').exists():
-        p = subprocess.Popen(['/usr/bin/sudo', str(WG_PATH), 'show', 'all', 'dump'],
-                             stdout=subprocess.PIPE,
-                             stderr=subprocess.PIPE,
-                             )
-        p.wait()
-        if p.returncode != 0:
-            print('Failed to run `wg show all dump`:')
-            print(p.stdout.read().decode().strip())
-            print(p.stderr.read().decode().strip())
-            return []
-        lines = p.stdout.read().decode().strip().splitlines()
-        return lines
-    return '''
-wg0	qJ1YWXV6nPmouAditrRahp+5X/DlBJD02ZPkFjbLdE4=	iSOYKa61gszRvGnA4+IMkxEp364e1LrIcGuXcM4IeU8=	0	off
-wg0	YLA3Gq/GW0QrQQfPA5wq7zfXnQI94a7oA8780hwHxWU=	(none)	143.178.241.68:1194	10.88.88.1/32,192.168.2.0/24	1630599999	0	0	off
-wg0	YLA3Gq/GW0QrQQfPA5wq7zfXnQI94a7oA8780hwHxWU=	(none)	143.178.241.68:1194	10.88.88.1/32,192.168.2.0/24	0	0	0	off
-wg1	my_privkey	my_pubkey	0	off
-wg1	peer_pubkey	(none)	143.178.241.68:1194	10.88.88.1/32,192.168.2.0/24	0	0	0	off
-'''.strip().splitlines()
-
-def current_status_by_interface():
-    last_interface = None
-    data = _get_wg_status()
-    interface_status = {}
-    status_by_interface = {}
-    peers = []
-    for line in data:
-        parts = line.split('\t')
-        iface = parts[0]
-        if iface != last_interface and interface_status:
-            status_by_interface[last_interface] = interface_status
-            interface_status = {}
-
-        if len(parts) == 5:
-            iface, private_key, public_key, listen_port, fwmark = parts
-            interface_status['my_privkey'] = private_key
-            interface_status['peers'] = []
-            last_interface = iface
-        elif len(parts) == 9:
-            iface, public_key, preshared_key, endpoint, allowed_ips, latest_handshake, transfer_rx, transfer_tx, persistent_keepalive = parts
-            peer_data = {'public_key': public_key,
-                         'rx': transfer_rx,
-                         'tx': transfer_tx,
-                         'latest_handshake': latest_handshake,
-                         'up': int(latest_handshake) > 0,
-                         }
-            interface_status['peers'].append(peer_data)
-            interface_status['peers'] = sorted(interface_status['peers'], key=lambda x: not x['up'])
+        if use_kmod:
+            serve_pwd = self.serve_sudo_pwd()
+            subprocess.run(['/usr/bin/sudo', '-S', 'ip', 'link', 'add', interface_name, 'type', 'wireguard'],
+                            stdin=serve_pwd.stdout,
+                            check=True)
+            self.config_interface(profile, config_file)
         else:
-            raise ValueError("Can't parse line %s, it has %s parts", line, len(parts))
+            self.start_daemon(profile, config_file)
 
-    if last_interface:
-        status_by_interface[last_interface] = interface_status
-    return status_by_interface
+
+    def start_daemon(self, profile, config_file):
+        serve_pwd = self.serve_sudo_pwd()
+        p = subprocess.Popen(['/usr/bin/sudo', '-S', '/usr/bin/python3', 'src/daemon.py', profile['profile_name'], self._sudo_pwd],
+                              stdout=subprocess.PIPE,
+                              stderr=subprocess.PIPE,
+                              stdin=serve_pwd.stdout,
+                              start_new_session=True,
+                            )
+        print('started daemon')
+
+    def config_interface(self, profile, config_file):
+        interface_name = profile['interface_name']
+        log.info('Configuring interface %s', interface_name)
+        serve_pwd = self.serve_sudo_pwd()
+        subprocess.run(['/usr/bin/sudo', '-S', 'ip', 'link', 'set', 'down', 'dev', interface_name], check=False)
+        log.info('Interface down')
+
+        serve_pwd = self.serve_sudo_pwd()
+        p = subprocess.Popen(['/usr/bin/sudo', '-S', str(WG_PATH),
+                              'setconf', interface_name, str(config_file)],
+                              stdin=serve_pwd.stdout,
+                              stdout=subprocess.PIPE,
+                              stderr=subprocess.PIPE,
+                              )
+        p.wait()
+        log.info('Interface %s configured with %s', interface_name, config_file)
+        err = p.stderr.read().decode()
+        if p.returncode != 0:
+            log.error('But failed!')
+            log.error(p.stdout.read().decode())
+            log.error(err.strip())
+            return err
+
+        log.info('Successfully')
+        # TODO: check return codes
+        serve_pwd = self.serve_sudo_pwd()
+        subprocess.run(['/usr/bin/sudo', '-S', 'ip', 'address', 'add', 'dev', interface_name, profile['ip_address']], 
+                        stdin=serve_pwd.stdout,
+                        check=True)
+        log.info('Address set')
+        serve_pwd = self.serve_sudo_pwd()
+        subprocess.run(['/usr/bin/sudo', '-S', 'ip', 'link', 'set', 'up', 'dev', interface_name],
+                        stdin=serve_pwd.stdout,
+                        check=True)
+        log.info('Interface up')
+
+        for extra_route in profile['extra_routes'].split(','):
+            extra_route = extra_route.strip()
+            if not extra_route:
+                continue
+            serve_pwd = self.serve_sudo_pwd()
+            subprocess.run(['/usr/bin/sudo', '-S', 'ip', 'route', 'add', extra_route, 'dev', interface_name],
+                            stdin=serve_pwd.stdout,
+                            check=True)
+
+    def disconnect(self, interface_name):
+        # It is fine to have this fail, it is only trying to cleanup before starting
+        serve_pwd = self.serve_sudo_pwd()
+        subprocess.run(['/usr/bin/sudo', '-S', 'ip', 'link', 'del', 'dev', interface_name],
+                       stdin=serve_pwd.stdout,
+                       stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+                       check=False)
+
+    def _get_wg_status(self):
+        if Path('/usr/bin/sudo').exists():
+            serve_pwd = self.serve_sudo_pwd()
+            p = subprocess.Popen(['/usr/bin/sudo', '-S', str(WG_PATH), 'show', 'all', 'dump'],
+                                 stdin=serve_pwd.stdout,
+                                 stdout=subprocess.PIPE,
+                                 stderr=subprocess.PIPE,
+                                 )
+            p.wait()
+            if p.returncode != 0:
+                print('Failed to run `wg show all dump`:')
+                print(p.stdout.read().decode().strip())
+                print(p.stderr.read().decode().strip())
+                return []
+            lines = p.stdout.read().decode().strip().splitlines()
+            return lines
+        return '''
+    wg0	qJ1YWXV6nPmouAditrRahp+5X/DlBJD02ZPkFjbLdE4=	iSOYKa61gszRvGnA4+IMkxEp364e1LrIcGuXcM4IeU8=	0	off
+    wg0	YLA3Gq/GW0QrQQfPA5wq7zfXnQI94a7oA8780hwHxWU=	(none)	143.178.241.68:1194	10.88.88.1/32,192.168.2.0/24	1630599999	0	0	off
+    wg0	YLA3Gq/GW0QrQQfPA5wq7zfXnQI94a7oA8780hwHxWU=	(none)	143.178.241.68:1194	10.88.88.1/32,192.168.2.0/24	0	0	0	off
+    wg1	my_privkey	my_pubkey	0	off
+    wg1	peer_pubkey	(none)	143.178.241.68:1194	10.88.88.1/32,192.168.2.0/24	0	0	0	off
+    '''.strip().splitlines()
+
+    def current_status_by_interface(self):
+        last_interface = None
+        data = self._get_wg_status()
+        interface_status = {}
+        status_by_interface = {}
+        peers = []
+        for line in data:
+            parts = line.split('\t')
+            iface = parts[0]
+            if iface != last_interface and interface_status:
+                status_by_interface[last_interface] = interface_status
+                interface_status = {}
+
+            if len(parts) == 5:
+                iface, private_key, public_key, listen_port, fwmark = parts
+                interface_status['my_privkey'] = private_key
+                interface_status['peers'] = []
+                last_interface = iface
+            elif len(parts) == 9:
+                iface, public_key, preshared_key, endpoint, allowed_ips, latest_handshake, transfer_rx, transfer_tx, persistent_keepalive = parts
+                peer_data = {'public_key': public_key,
+                             'rx': transfer_rx,
+                             'tx': transfer_tx,
+                             'latest_handshake': latest_handshake,
+                             'up': int(latest_handshake) > 0,
+                             }
+                interface_status['peers'].append(peer_data)
+                interface_status['peers'] = sorted(interface_status['peers'], key=lambda x: not x['up'])
+            else:
+                raise ValueError("Can't parse line %s, it has %s parts", line, len(parts))
+
+        if last_interface:
+            status_by_interface[last_interface] = interface_status
+        return status_by_interface

--- a/src/interface.py
+++ b/src/interface.py
@@ -6,118 +6,124 @@ from pathlib import Path
 WG_PATH = Path(os.getcwd()) / "vendored/wg"
 log = logging.getLogger(__name__)
 
-def _connect(profile, config_file, use_kmod):
-    interface_name = profile['interface_name']
-    disconnect(interface_name)
+class Interface:
+    def __init__(self, sudo):
+        self._sudo = sudo
 
-    if use_kmod:
-        subprocess.run(['sudo', 'ip', 'link', 'add', interface_name, 'type', 'wireguard'], check=True)
-        config_interface(profile, config_file)
-    else:
-        start_daemon(profile, config_file)
+    def _connect(self, profile, config_file, use_kmod):
+        interface_name = profile['interface_name']
+        self.disconnect(interface_name)
 
-
-def start_daemon(profile, config_file):
-    p = subprocess.Popen(['/usr/bin/python3', 'src/daemon.py', profile['profile_name']],
-                          stdout=subprocess.PIPE,
-                          stderr=subprocess.PIPE,
-                          stdin=subprocess.DEVNULL,
-                          start_new_session=True,
-                        )
-    print('started daemon')
-
-def config_interface(profile, config_file):
-    interface_name = profile['interface_name']
-    log.info('Configuring interface %s', interface_name)
-    subprocess.run(['/usr/bin/sudo', 'ip', 'link', 'set', 'down', 'dev', interface_name], check=False)
-    log.info('Interface down')
-
-    p = subprocess.Popen(['/usr/bin/sudo', str(WG_PATH),
-                          'setconf', interface_name, str(config_file)],
-                          stdout=subprocess.PIPE,
-                          stderr=subprocess.PIPE,
-                          )
-    p.wait()
-    log.info('Interface %s configured with %s', interface_name, config_file)
-    err = p.stderr.read().decode()
-    if p.returncode != 0:
-        log.error('But failed!')
-        log.error(p.stdout.read().decode())
-        log.error(err.strip())
-        return err
-
-    log.info('Successfully')
-    # TODO: check return codes
-    subprocess.run(['/usr/bin/sudo', 'ip', 'address', 'add', 'dev', interface_name, profile['ip_address']], check=True)
-    log.info('Address set')
-    subprocess.run(['/usr/bin/sudo', 'ip', 'link', 'set', 'up', 'dev', interface_name], check=True)
-    log.info('Interface up')
-
-    for extra_route in profile['extra_routes'].split(','):
-        extra_route = extra_route.strip()
-        if not extra_route:
-            continue
-        subprocess.run(['/usr/bin/sudo', 'ip', 'route', 'add', extra_route, 'dev', interface_name], check=True)
-
-def disconnect(interface_name):
-    # It is fine to have this fail, it is only trying to cleanup before starting
-    subprocess.run(['/usr/bin/sudo', 'ip', 'link', 'del', 'dev', interface_name],
-                   stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
-                   check=False)
-
-def _get_wg_status():
-    if Path('/usr/bin/sudo').exists():
-        p = subprocess.Popen(['/usr/bin/sudo', str(WG_PATH), 'show', 'all', 'dump'],
-                             stdout=subprocess.PIPE,
-                             stderr=subprocess.PIPE,
-                             )
-        p.wait()
-        if p.returncode != 0:
-            print('Failed to run `wg show all dump`:')
-            print(p.stdout.read().decode().strip())
-            print(p.stderr.read().decode().strip())
-            return []
-        lines = p.stdout.read().decode().strip().splitlines()
-        return lines
-    return '''
-wg0	qJ1YWXV6nPmouAditrRahp+5X/DlBJD02ZPkFjbLdE4=	iSOYKa61gszRvGnA4+IMkxEp364e1LrIcGuXcM4IeU8=	0	off
-wg0	YLA3Gq/GW0QrQQfPA5wq7zfXnQI94a7oA8780hwHxWU=	(none)	143.178.241.68:1194	10.88.88.1/32,192.168.2.0/24	1630599999	0	0	off
-wg0	YLA3Gq/GW0QrQQfPA5wq7zfXnQI94a7oA8780hwHxWU=	(none)	143.178.241.68:1194	10.88.88.1/32,192.168.2.0/24	0	0	0	off
-wg1	my_privkey	my_pubkey	0	off
-wg1	peer_pubkey	(none)	143.178.241.68:1194	10.88.88.1/32,192.168.2.0/24	0	0	0	off
-'''.strip().splitlines()
-
-def current_status_by_interface():
-    last_interface = None
-    data = _get_wg_status()
-    interface_status = {}
-    status_by_interface = {}
-    peers = []
-    for line in data:
-        parts = line.split('\t')
-        iface = parts[0]
-        if iface != last_interface and interface_status:
-            status_by_interface[last_interface] = interface_status
-            interface_status = {}
-
-        if len(parts) == 5:
-            iface, private_key, public_key, listen_port, fwmark = parts
-            interface_status['my_privkey'] = private_key
-            interface_status['peers'] = []
-            last_interface = iface
-        elif len(parts) == 9:
-            iface, public_key, preshared_key, endpoint, allowed_ips, latest_handshake, transfer_rx, transfer_tx, persistent_keepalive = parts
-            peer_data = {'public_key': public_key,
-                         'rx': transfer_rx,
-                         'tx': transfer_tx,
-                         'latest_handshake': latest_handshake,
-                         'up': int(latest_handshake) > 0,
-                         }
-            interface_status['peers'].append(peer_data)
-            interface_status['peers'] = sorted(interface_status['peers'], key=lambda x: not x['up'])
+        if use_kmod:
+            subprocess.run(self._sudo + ['ip', 'link', 'add', interface_name, 'type', 'wireguard'], check=True)
+            self.config_interface(profile, config_file)
         else:
-            raise ValueError("Can't parse line %s, it has %s parts", line, len(parts))
+            self.start_daemon(profile, config_file)
 
-    if last_interface:
-        status_by_interface[last_interface] = interface_status
-    return status_by_interface
+
+    def start_daemon(self, profile, config_file):
+        p = subprocess.Popen(['/usr/bin/python3', 'src/daemon.py', profile['profile_name']],
+                              stdout=subprocess.PIPE,
+                              stderr=subprocess.PIPE,
+                              stdin=subprocess.DEVNULL,
+                              start_new_session=True,
+                            )
+        print('started daemon')
+
+    def config_interface(self, profile, config_file):
+        interface_name = profile['interface_name']
+        log.info('Configuring interface %s', interface_name)
+        subprocess.run(self._sudo + ['ip', 'link', 'set', 'down', 'dev', interface_name], check=False)
+        log.info('Interface down')
+
+        p = subprocess.Popen(self._sudo + [str(WG_PATH),
+                              'setconf', interface_name, str(config_file)],
+                              shell=True,
+                              stdout=subprocess.PIPE,
+                              stderr=subprocess.PIPE,
+                              )
+        p.wait()
+        log.info('Interface %s configured with %s', interface_name, config_file)
+        err = p.stderr.read().decode()
+        if p.returncode != 0:
+            log.error('But failed!')
+            log.error(p.stdout.read().decode())
+            log.error(err.strip())
+            return err
+
+        log.info('Successfully')
+        # TODO: check return codes
+        subprocess.run(self._sudo + ['ip', 'address', 'add', 'dev', interface_name, profile['ip_address']], check=True)
+        log.info('Address set')
+        subprocess.run(self._sudo + ['ip', 'link', 'set', 'up', 'dev', interface_name], check=True)
+        log.info('Interface up')
+
+        for extra_route in profile['extra_routes'].split(','):
+            extra_route = extra_route.strip()
+            if not extra_route:
+                continue
+            subprocess.run(self._sudo + ['ip', 'route', 'add', extra_route, 'dev', interface_name], check=True)
+
+    def disconnect(self, interface_name):
+        # It is fine to have this fail, it is only trying to cleanup before starting
+        subprocess.run(self._sudo + ['ip', 'link', 'del', 'dev', interface_name],
+                       stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+                       check=False)
+
+    def _get_wg_status(self):
+        if Path('/usr/bin/sudo').exists():
+            p = subprocess.Popen(self._sudo + [str(WG_PATH), 'show', 'all', 'dump'],
+                                 shell=True,
+                                 stdout=subprocess.PIPE,
+                                 stderr=subprocess.PIPE,
+                                 )
+            p.wait()
+            if p.returncode != 0:
+                print('Failed to run `wg show all dump`:')
+                print(p.stdout.read().decode().strip())
+                print(p.stderr.read().decode().strip())
+                return []
+            lines = p.stdout.read().decode().strip().splitlines()
+            return lines
+        return '''
+    wg0	qJ1YWXV6nPmouAditrRahp+5X/DlBJD02ZPkFjbLdE4=	iSOYKa61gszRvGnA4+IMkxEp364e1LrIcGuXcM4IeU8=	0	off
+    wg0	YLA3Gq/GW0QrQQfPA5wq7zfXnQI94a7oA8780hwHxWU=	(none)	143.178.241.68:1194	10.88.88.1/32,192.168.2.0/24	1630599999	0	0	off
+    wg0	YLA3Gq/GW0QrQQfPA5wq7zfXnQI94a7oA8780hwHxWU=	(none)	143.178.241.68:1194	10.88.88.1/32,192.168.2.0/24	0	0	0	off
+    wg1	my_privkey	my_pubkey	0	off
+    wg1	peer_pubkey	(none)	143.178.241.68:1194	10.88.88.1/32,192.168.2.0/24	0	0	0	off
+    '''.strip().splitlines()
+
+    def current_status_by_interface(self):
+        last_interface = None
+        data = self._get_wg_status()
+        interface_status = {}
+        status_by_interface = {}
+        peers = []
+        for line in data:
+            parts = line.split('\t')
+            iface = parts[0]
+            if iface != last_interface and interface_status:
+                status_by_interface[last_interface] = interface_status
+                interface_status = {}
+
+            if len(parts) == 5:
+                iface, private_key, public_key, listen_port, fwmark = parts
+                interface_status['my_privkey'] = private_key
+                interface_status['peers'] = []
+                last_interface = iface
+            elif len(parts) == 9:
+                iface, public_key, preshared_key, endpoint, allowed_ips, latest_handshake, transfer_rx, transfer_tx, persistent_keepalive = parts
+                peer_data = {'public_key': public_key,
+                             'rx': transfer_rx,
+                             'tx': transfer_tx,
+                             'latest_handshake': latest_handshake,
+                             'up': int(latest_handshake) > 0,
+                             }
+                interface_status['peers'].append(peer_data)
+                interface_status['peers'] = sorted(interface_status['peers'], key=lambda x: not x['up'])
+            else:
+                raise ValueError("Can't parse line %s, it has %s parts", line, len(parts))
+
+        if last_interface:
+            status_by_interface[last_interface] = interface_status
+        return status_by_interface

--- a/src/interface.py
+++ b/src/interface.py
@@ -141,6 +141,8 @@ class Interface:
                              'latest_handshake': latest_handshake,
                              'up': int(latest_handshake) > 0,
                              }
+                if not interface_status.get('peers'):
+                    interface_status['peers'] = []
                 interface_status['peers'].append(peer_data)
                 interface_status['peers'] = sorted(interface_status['peers'], key=lambda x: not x['up'])
             else:

--- a/src/test.py
+++ b/src/test.py
@@ -1,0 +1,14 @@
+import subprocess
+from pathlib import Path
+
+def test_sudo(sudo_pwd):
+        if not Path('/usr/bin/sudo').exists():
+            return False
+
+        subprocess.run(['/usr/bin/sudo', '-k'])    
+        try:
+            serve_pwd = subprocess.Popen(['echo', sudo_pwd], stdout=subprocess.PIPE)
+            subprocess.run(['/usr/bin/sudo', '-S', 'echo', 'Check for sudo'], stdin=serve_pwd.stdout, check=True)
+        except subprocess.CalledProcessError:
+            return False
+        return True

--- a/src/vpn.py
+++ b/src/vpn.py
@@ -63,7 +63,7 @@ class Vpn:
             return stdout.strip()
         return stderr.strip()
 
-    def save_profile(self, profile_name, ip_address, private_key, interface_name, extra_routes, peers):
+    def save_profile(self, profile_name, ip_address, private_key, interface_name, extra_routes, dns_servers, peers):
         if '/' in profile_name:
             return '"/" is not allowed in profile names'
 
@@ -121,6 +121,14 @@ class Vpn:
                 except Exception as e:
                     return 'Bad route ' + route + ': ' + str(e)
 
+        if dns_servers:
+            for dns in dns_servers.split(','):
+                dns = dns.strip()
+                try:
+                    IPv4Network(dns, strict=False)
+                except Exception as e:
+                    return 'Bad dns ' + dns + ': ' + str(e)
+
         PROFILE_DIR = PROFILES_DIR / profile_name
         PROFILE_DIR.mkdir(exist_ok=True, parents=True)
 
@@ -133,6 +141,7 @@ class Vpn:
 
         profile = {'peers': peers,
                    'ip_address': ip_address,
+                   'dns_servers': dns_servers,
                    'extra_routes': extra_routes,
                    'profile_name': profile_name,
                    'private_key': private_key,

--- a/src/vpn.py
+++ b/src/vpn.py
@@ -19,135 +19,150 @@ LOG_DIR = Path('/home/phablet/.cache/wireguard.davidv.dev')
 
 LOG_DIR.mkdir(parents=True, exist_ok=True)
 
-def can_use_kernel_module():
-    if not Path('/usr/bin/sudo').exists():
-        return False
-    try:
-        subprocess.run(['sudo', 'ip', 'link', 'add', 'test_wg0', 'type', 'wireguard'], check=True)
-        subprocess.run(['sudo', 'ip', 'link', 'del', 'test_wg0', 'type', 'wireguard'], check=True)
-    except subprocess.CalledProcessError:
-        return False
-    return True
+class Vpn:
+    def __init__(self):
+        self._pwd = ''
 
-def _connect(profile_name,  use_kmod):
-    try:
-        return interface._connect(get_profile(profile_name), PROFILES_DIR / profile_name / 'config.ini', use_kmod)
-    except Exception as e:
-        return str(e)
+    def set_pwd(self, sudo_pwd):
+        self._sudo_pwd = sudo_pwd;
+        self.interface = interface.Interface(sudo_pwd)
 
-def genkey():
-    return subprocess.check_output(['vendored/wg', 'genkey']).strip()
+    def serve_sudo_pwd(self):
+        return subprocess.Popen(['echo', self._sudo_pwd], stdout=subprocess.PIPE)
 
-def genpubkey(privkey):
-    p = subprocess.Popen(['vendored/wg', 'pubkey'],
-                         stdin=subprocess.PIPE,
-                         stdout=subprocess.PIPE,
-                         stderr=subprocess.PIPE,)
-
-    stdout, stderr = p.communicate(privkey.encode())
-    if p.returncode == 0:
-        return stdout.strip()
-    return stderr.strip()
-
-def save_profile(profile_name, ip_address, private_key, interface_name, extra_routes, peers):
-    if '/' in profile_name:
-        return '"/" is not allowed in profile names'
-
-    if len(private_key) != 44:
-        return 'Peer key must be exactly 44 bytes long'
-
-    _pub = genpubkey(private_key)
-    if len(_pub) != 44:
-        return 'Bad private key: ' + _pub
-
-    try:
-        IPv4Network(ip_address, strict=False)
-    except Exception as e:
-        return 'Bad ip address: ' + str(e)
-
-    try:
-        base64.b64decode(private_key)
-    except Exception as e:
-        return 'Bad private key'
-
-    for peer in peers:
-        if not peer['name']:
-            return 'Peer name is incomplete'
-
-        if len(peer['key']) != 44:
-            return 'Peer key ({name}) must be exactly 44 bytes long'.format_map(peer)
+    def can_use_kernel_module(self):
+        if not Path('/usr/bin/sudo').exists():
+            return False
         try:
-            base64.b64decode(peer['key'])
+            serve_pwd = self.serve_sudo_pwd()
+            subprocess.run(['/usr/bin/sudo', '-S', 'ip', 'link', 'add', 'test_wg0', 'type', 'wireguard'], stdin=serve_pwd.stdout, check=True)
+            serve_pwd = self.serve_sudo_pwd()
+            subprocess.run(['/usr/bin/sudo', '-S', 'ip', 'link', 'del', 'test_wg0', 'type', 'wireguard'], stdin=serve_pwd.stdout, check=True)
+        except subprocess.CalledProcessError:
+            return False
+        return True
+
+    def _connect(self, profile_name,  use_kmod):
+        try:
+            return self.interface._connect(self.get_profile(profile_name), PROFILES_DIR / profile_name / 'config.ini', use_kmod)
         except Exception as e:
-            return 'Bad peer ({name}) key'.format_map(peer)
+            return str(e)
 
-        if ':' not in peer['endpoint']:
-            return 'Bad endpoint ({name}) -- missing ":"'.format_map(peer)
+    def genkey(self):
+        return subprocess.check_output(['vendored/wg', 'genkey']).strip()
 
-        allowed_prefixes = peer['allowed_prefixes']
-        for allowed_prefix in allowed_prefixes.split(','):
-            allowed_prefix = allowed_prefix.strip()
-            try:
-                IPv4Network(allowed_prefix, strict=False)
-            except Exception as e:
-                return 'Bad peer ({name}) prefix '.format_map(peer) + allowed_prefix + ': ' + str(e)
+    def genpubkey(self, privkey):
+        p = subprocess.Popen(['vendored/wg', 'pubkey'],
+                             stdin=subprocess.PIPE,
+                             stdout=subprocess.PIPE,
+                             stderr=subprocess.PIPE,)
 
-    if extra_routes:
-        for route in extra_routes.split(','):
-            route = route.strip()
-            try:
-                IPv4Network(route, strict=False)
-            except Exception as e:
-                return 'Bad route ' + route + ': ' + str(e)
+        stdout, stderr = p.communicate(privkey.encode())
+        if p.returncode == 0:
+            return stdout.strip()
+        return stderr.strip()
 
-    PROFILE_DIR = PROFILES_DIR / profile_name
-    PROFILE_DIR.mkdir(exist_ok=True, parents=True)
+    def save_profile(self, profile_name, ip_address, private_key, interface_name, extra_routes, peers):
+        if '/' in profile_name:
+            return '"/" is not allowed in profile names'
 
-    PRIV_KEY_PATH = PROFILE_DIR / 'privkey'
-    PROFILE_FILE = PROFILE_DIR / 'profile.json'
-    CONFIG_FILE = PROFILE_DIR / 'config.ini'
+        if len(private_key) != 44:
+            return 'Peer key must be exactly 44 bytes long'
 
-    with PRIV_KEY_PATH.open('w') as fd:
-        fd.write(private_key)
+        _pub = self.genpubkey(private_key)
+        if len(_pub) != 44:
+            return 'Bad private key: ' + _pub
 
-    profile = {'peers': peers,
-               'ip_address': ip_address,
-               'extra_routes': extra_routes,
-               'profile_name': profile_name,
-               'private_key': private_key,
-               'interface_name': interface_name,
-               }
-    with PROFILE_FILE.open('w') as fd:
-        json.dump(profile, fd, indent=4, sort_keys=True)
+        try:
+            IPv4Network(ip_address, strict=False)
+        except Exception as e:
+            return 'Bad ip address: ' + str(e)
 
-    with CONFIG_FILE.open('w') as fd:
-        fd.write(textwrap.dedent('''
-        [Interface]
-        #Profile = {profile_name}
-        PrivateKey = {private_key}
-        ''').format_map(profile))
+        try:
+            base64.b64decode(private_key)
+        except Exception as e:
+            return 'Bad private key'
+
         for peer in peers:
+            if not peer['name']:
+                return 'Peer name is incomplete'
+
+            if len(peer['key']) != 44:
+                return 'Peer key ({name}) must be exactly 44 bytes long'.format_map(peer)
+            try:
+                base64.b64decode(peer['key'])
+            except Exception as e:
+                return 'Bad peer ({name}) key'.format_map(peer)
+
+            if ':' not in peer['endpoint']:
+                return 'Bad endpoint ({name}) -- missing ":"'.format_map(peer)
+
+            allowed_prefixes = peer['allowed_prefixes']
+            for allowed_prefix in allowed_prefixes.split(','):
+                allowed_prefix = allowed_prefix.strip()
+                try:
+                    IPv4Network(allowed_prefix, strict=False)
+                except Exception as e:
+                    return 'Bad peer ({name}) prefix '.format_map(peer) + allowed_prefix + ': ' + str(e)
+
+        if extra_routes:
+            for route in extra_routes.split(','):
+                route = route.strip()
+                try:
+                    IPv4Network(route, strict=False)
+                except Exception as e:
+                    return 'Bad route ' + route + ': ' + str(e)
+
+        PROFILE_DIR = PROFILES_DIR / profile_name
+        PROFILE_DIR.mkdir(exist_ok=True, parents=True)
+
+        PRIV_KEY_PATH = PROFILE_DIR / 'privkey'
+        PROFILE_FILE = PROFILE_DIR / 'profile.json'
+        CONFIG_FILE = PROFILE_DIR / 'config.ini'
+
+        with PRIV_KEY_PATH.open('w') as fd:
+            fd.write(private_key)
+
+        profile = {'peers': peers,
+                   'ip_address': ip_address,
+                   'extra_routes': extra_routes,
+                   'profile_name': profile_name,
+                   'private_key': private_key,
+                   'interface_name': interface_name,
+                   }
+        with PROFILE_FILE.open('w') as fd:
+            json.dump(profile, fd, indent=4, sort_keys=True)
+
+        with CONFIG_FILE.open('w') as fd:
             fd.write(textwrap.dedent('''
-            [Peer]
-            #Name = {name}
-            PublicKey = {key}
-            AllowedIPs = {allowed_prefixes}
-            Endpoint = {endpoint}
-            PersistentKeepalive = 5
-            '''.format_map(peer)))
+            [Interface]
+            #Profile = {profile_name}
+            PrivateKey = {private_key}
+            ''').format_map(profile))
+            for peer in peers:
+                fd.write(textwrap.dedent('''
+                [Peer]
+                #Name = {name}
+                PublicKey = {key}
+                AllowedIPs = {allowed_prefixes}
+                Endpoint = {endpoint}
+                PersistentKeepalive = 5
+                '''.format_map(peer)))
 
-def get_profile(profile):
-    with (PROFILES_DIR / profile / 'profile.json').open() as fd:
-        data = json.load(fd)
-        return data
-
-def list_profiles():
-    profiles = []
-    for path in PROFILES_DIR.glob('*/profile.json'):
-        with path.open() as fd:
+    def get_profile(self, profile):
+        with (PROFILES_DIR / profile / 'profile.json').open() as fd:
             data = json.load(fd)
-            data.setdefault('interface_name', 'wg0')
-            data['c_status'] = {}
-            print(data, flush=True)
-            profiles.append(data)
-    return profiles
+            return data
+
+    def list_profiles(self):
+        profiles = []
+        for path in PROFILES_DIR.glob('*/profile.json'):
+            with path.open() as fd:
+                data = json.load(fd)
+                data.setdefault('interface_name', 'wg0')
+                data['c_status'] = {}
+                print(data, flush=True)
+                profiles.append(data)
+        return profiles
+
+instance = Vpn()

--- a/src/vpn.py
+++ b/src/vpn.py
@@ -1,6 +1,7 @@
 import subprocess
 import time
 import os
+import shutil
 import base64
 import json
 import textwrap
@@ -166,6 +167,16 @@ class Vpn:
                     Endpoint = {endpoint}
                     PersistentKeepalive = 5
                     '''.format_map(peer)))
+
+    def delete_profile(self, profile):
+        print(profile)
+        PROFILE_DIR = PROFILES_DIR / profile
+        print(PROFILE_DIR)
+        try:
+            shutil.rmtree(PROFILE_DIR.as_posix())
+        except OSError as e:
+            return 'Error: ' + PROFILE_DIR + ': ' + e.strerror
+
 
     def get_profile(self, profile):
         with (PROFILES_DIR / profile / 'profile.json').open() as fd:

--- a/src/vpn.py
+++ b/src/vpn.py
@@ -19,135 +19,148 @@ LOG_DIR = Path('/home/phablet/.cache/wireguard.davidv.dev')
 
 LOG_DIR.mkdir(parents=True, exist_ok=True)
 
-def can_use_kernel_module():
-    if not Path('/usr/bin/sudo').exists():
-        return False
-    try:
-        subprocess.run(['sudo', 'ip', 'link', 'add', 'test_wg0', 'type', 'wireguard'], check=True)
-        subprocess.run(['sudo', 'ip', 'link', 'del', 'test_wg0', 'type', 'wireguard'], check=True)
-    except subprocess.CalledProcessError:
-        return False
-    return True
+class Vpn:
+    def __init__(self):
+        self._pwd = ''
 
-def _connect(profile_name,  use_kmod):
-    try:
-        return interface._connect(get_profile(profile_name), PROFILES_DIR / profile_name / 'config.ini', use_kmod)
-    except Exception as e:
-        return str(e)
+    def set_pwd(self, pwd):
+        self._pwd = pwd;
+        self.interface = interface.Interface(self.sudo())
 
-def genkey():
-    return subprocess.check_output(['vendored/wg', 'genkey']).strip()
+    def sudo(self):
+        return ['echo', self._pwd, '|', '/usr/bin/sudo', '-S']
 
-def genpubkey(privkey):
-    p = subprocess.Popen(['vendored/wg', 'pubkey'],
-                         stdin=subprocess.PIPE,
-                         stdout=subprocess.PIPE,
-                         stderr=subprocess.PIPE,)
-
-    stdout, stderr = p.communicate(privkey.encode())
-    if p.returncode == 0:
-        return stdout.strip()
-    return stderr.strip()
-
-def save_profile(profile_name, ip_address, private_key, interface_name, extra_routes, peers):
-    if '/' in profile_name:
-        return '"/" is not allowed in profile names'
-
-    if len(private_key) != 44:
-        return 'Peer key must be exactly 44 bytes long'
-
-    _pub = genpubkey(private_key)
-    if len(_pub) != 44:
-        return 'Bad private key: ' + _pub
-
-    try:
-        IPv4Network(ip_address, strict=False)
-    except Exception as e:
-        return 'Bad ip address: ' + str(e)
-
-    try:
-        base64.b64decode(private_key)
-    except Exception as e:
-        return 'Bad private key'
-
-    for peer in peers:
-        if not peer['name']:
-            return 'Peer name is incomplete'
-
-        if len(peer['key']) != 44:
-            return 'Peer key ({name}) must be exactly 44 bytes long'.format_map(peer)
+    def can_use_kernel_module(self):
+        if not Path('/usr/bin/sudo').exists():
+            return False
         try:
-            base64.b64decode(peer['key'])
+            subprocess.run(self.sudo() + ['ip', 'link', 'add', 'test_wg0', 'type', 'wireguard'], check=True)
+            subprocess.run(self.sudo() + ['ip', 'link', 'del', 'test_wg0', 'type', 'wireguard'], check=True)
+        except subprocess.CalledProcessError:
+            return False
+        return True
+
+    def _connect(self, profile_name,  use_kmod):
+        try:
+            return self.interface._connect(self.get_profile(profile_name), PROFILES_DIR / profile_name / 'config.ini', use_kmod)
         except Exception as e:
-            return 'Bad peer ({name}) key'.format_map(peer)
+            return str(e)
 
-        if ':' not in peer['endpoint']:
-            return 'Bad endpoint ({name}) -- missing ":"'.format_map(peer)
+    def genkey(self):
+        return subprocess.check_output(['vendored/wg', 'genkey']).strip()
 
-        allowed_prefixes = peer['allowed_prefixes']
-        for allowed_prefix in allowed_prefixes.split(','):
-            allowed_prefix = allowed_prefix.strip()
-            try:
-                IPv4Network(allowed_prefix, strict=False)
-            except Exception as e:
-                return 'Bad peer ({name}) prefix '.format_map(peer) + allowed_prefix + ': ' + str(e)
+    def genpubkey(self, privkey):
+        p = subprocess.Popen(['vendored/wg', 'pubkey'],
+                             stdin=subprocess.PIPE,
+                             stdout=subprocess.PIPE,
+                             stderr=subprocess.PIPE,)
 
-    if extra_routes:
-        for route in extra_routes.split(','):
-            route = route.strip()
-            try:
-                IPv4Network(route, strict=False)
-            except Exception as e:
-                return 'Bad route ' + route + ': ' + str(e)
+        stdout, stderr = p.communicate(privkey.encode())
+        if p.returncode == 0:
+            return stdout.strip()
+        return stderr.strip()
 
-    PROFILE_DIR = PROFILES_DIR / profile_name
-    PROFILE_DIR.mkdir(exist_ok=True, parents=True)
+    def save_profile(self, profile_name, ip_address, private_key, interface_name, extra_routes, peers):
+        if '/' in profile_name:
+            return '"/" is not allowed in profile names'
 
-    PRIV_KEY_PATH = PROFILE_DIR / 'privkey'
-    PROFILE_FILE = PROFILE_DIR / 'profile.json'
-    CONFIG_FILE = PROFILE_DIR / 'config.ini'
+        if len(private_key) != 44:
+            return 'Peer key must be exactly 44 bytes long'
 
-    with PRIV_KEY_PATH.open('w') as fd:
-        fd.write(private_key)
+        _pub = self.genpubkey(private_key)
+        if len(_pub) != 44:
+            return 'Bad private key: ' + _pub
 
-    profile = {'peers': peers,
-               'ip_address': ip_address,
-               'extra_routes': extra_routes,
-               'profile_name': profile_name,
-               'private_key': private_key,
-               'interface_name': interface_name,
-               }
-    with PROFILE_FILE.open('w') as fd:
-        json.dump(profile, fd, indent=4, sort_keys=True)
+        try:
+            IPv4Network(ip_address, strict=False)
+        except Exception as e:
+            return 'Bad ip address: ' + str(e)
 
-    with CONFIG_FILE.open('w') as fd:
-        fd.write(textwrap.dedent('''
-        [Interface]
-        #Profile = {profile_name}
-        PrivateKey = {private_key}
-        ''').format_map(profile))
+        try:
+            base64.b64decode(private_key)
+        except Exception as e:
+            return 'Bad private key'
+
         for peer in peers:
+            if not peer['name']:
+                return 'Peer name is incomplete'
+
+            if len(peer['key']) != 44:
+                return 'Peer key ({name}) must be exactly 44 bytes long'.format_map(peer)
+            try:
+                base64.b64decode(peer['key'])
+            except Exception as e:
+                return 'Bad peer ({name}) key'.format_map(peer)
+
+            if ':' not in peer['endpoint']:
+                return 'Bad endpoint ({name}) -- missing ":"'.format_map(peer)
+
+            allowed_prefixes = peer['allowed_prefixes']
+            for allowed_prefix in allowed_prefixes.split(','):
+                allowed_prefix = allowed_prefix.strip()
+                try:
+                    IPv4Network(allowed_prefix, strict=False)
+                except Exception as e:
+                    return 'Bad peer ({name}) prefix '.format_map(peer) + allowed_prefix + ': ' + str(e)
+
+        if extra_routes:
+            for route in extra_routes.split(','):
+                route = route.strip()
+                try:
+                    IPv4Network(route, strict=False)
+                except Exception as e:
+                    return 'Bad route ' + route + ': ' + str(e)
+
+        PROFILE_DIR = PROFILES_DIR / profile_name
+        PROFILE_DIR.mkdir(exist_ok=True, parents=True)
+
+        PRIV_KEY_PATH = PROFILE_DIR / 'privkey'
+        PROFILE_FILE = PROFILE_DIR / 'profile.json'
+        CONFIG_FILE = PROFILE_DIR / 'config.ini'
+
+        with PRIV_KEY_PATH.open('w') as fd:
+            fd.write(private_key)
+
+        profile = {'peers': peers,
+                   'ip_address': ip_address,
+                   'extra_routes': extra_routes,
+                   'profile_name': profile_name,
+                   'private_key': private_key,
+                   'interface_name': interface_name,
+                   }
+        with PROFILE_FILE.open('w') as fd:
+            json.dump(profile, fd, indent=4, sort_keys=True)
+
+        with CONFIG_FILE.open('w') as fd:
             fd.write(textwrap.dedent('''
-            [Peer]
-            #Name = {name}
-            PublicKey = {key}
-            AllowedIPs = {allowed_prefixes}
-            Endpoint = {endpoint}
-            PersistentKeepalive = 5
-            '''.format_map(peer)))
+            [Interface]
+            #Profile = {profile_name}
+            PrivateKey = {private_key}
+            ''').format_map(profile))
+            for peer in peers:
+                fd.write(textwrap.dedent('''
+                [Peer]
+                #Name = {name}
+                PublicKey = {key}
+                AllowedIPs = {allowed_prefixes}
+                Endpoint = {endpoint}
+                PersistentKeepalive = 5
+                '''.format_map(peer)))
 
-def get_profile(profile):
-    with (PROFILES_DIR / profile / 'profile.json').open() as fd:
-        data = json.load(fd)
-        return data
-
-def list_profiles():
-    profiles = []
-    for path in PROFILES_DIR.glob('*/profile.json'):
-        with path.open() as fd:
+    def get_profile(self, profile):
+        with (PROFILES_DIR / profile / 'profile.json').open() as fd:
             data = json.load(fd)
-            data.setdefault('interface_name', 'wg0')
-            data['c_status'] = {}
-            print(data, flush=True)
-            profiles.append(data)
-    return profiles
+            return data
+
+    def list_profiles(self):
+        profiles = []
+        for path in PROFILES_DIR.glob('*/profile.json'):
+            with path.open() as fd:
+                data = json.load(fd)
+                data.setdefault('interface_name', 'wg0')
+                data['c_status'] = {}
+                print(data, flush=True)
+                profiles.append(data)
+        return profiles
+
+instance = Vpn()


### PR DESCRIPTION
Hi,
I implemented some missing features and also fixed some bugs.

### Sudo password popup - fixes https://github.com/DavidVentura/Wireguard_qml/issues/4
- 6dd567f7b63ea1c3759bed1b43cf1e065c8e7134
- e5cda82472a04e755879b797eb205124b1e7d03a
I implemented a potential insecure way, of doing it, because the password get's saved in a qml property and could be leaked by logs for example. Also the password gets echoed to the subprocess commands and would be visible in the shell itself.
Nevertheless it works and it is the best I could come up with.

### Preshared key and DNS - fixes https://github.com/DavidVentura/Wireguard_qml/issues/5
- 73c3457601a3f35af116544920fae5be1bc9e90d
- 95ba6e7af34bf6ebd0d1790a0fd36ce1baf7af71
The preshared key is straight forward, nothing special.
The DNS thing is more complicated and I am not sure, if this is the right way of doing it. Actually I thought this would be handled by the extra routes somehow, but that seems not to be the case.
I also looked at the debian manpage of wg-quick, how it is doing such things (https://manpages.debian.org/unstable/wireguard-tools/wg-quick.8.en.html), but the interface specific resolvconf command provided there, does not work out on UT.

### Bug: the userspace implementation was always used, even if the kernelmodule was recognized
- d2e0159f845314f881fae7b5fd18b17b26dfcd9a
- 8bbc34b6c49ea4569f12f24a9275c116f758ca28
Or at least, the daemon was always started. Then I saw in the code, that the daemon should not be used, if the kernel module is available.
The useUserspace QML setting, was at first never set in the PickProfilePage and second not updated, when switching back to the PickProfilePage. This is fixed now.

### InterfaceName was not set
- 0b3e15003257a7d86fdde450026857b7840e1f66
Somehow the interfacename was not set correctly. I am not sure, if this issue was a result of my changes or only happaning with the  kernelmodule way... however, I reworked the way, how the name is set.
It depends now on the count and index of the interface-item in the listmodel. -> wg0, wg1, wg2, etc.

### Other
- added action to delete interfaces from the list f806e190fdc981edd24e96bc74ccd16b533aa562
- fixed that the log got spammed, trying to get the inteface-status, if there was no interface yet 06a1c55f24e3c6dbf2d5cd9bf5c69b8d95303cfd
- fixed text color for the traffic-text, if a dark theme was used a60dde988dd224654be5f2d0b1951a2f84878e3a
- on saving a profile, qml tried to log an error, which did not occur a655d9f577db45a8d1664fa689feee18b3a44c8f

