### PR TITLE
convert clickable.json to clickable.yaml, add ignore_review_warnings

### DIFF
--- a/clickable.json
+++ b/clickable.json
@@ -1,5 +1,0 @@
-{
-  "builder": "cmake",
-  "kill": "qmlscene",
-  "clickable_minimum_required": "7"
-}

--- a/clickable.yaml
+++ b/clickable.yaml
@@ -1,0 +1,4 @@
+clickable_minimum_required: '7.4'
+builder: cmake
+kill: qmlscene
+ignore_review_warnings: true

--- a/clickable.yaml
+++ b/clickable.yaml
@@ -1,4 +1,4 @@
-clickable_minimum_required: '7.4'
+clickable_minimum_required: '7.3'
 builder: cmake
 kill: qmlscene
 ignore_review_warnings: true


### PR DESCRIPTION
The ignore_review_warnings parameter is needed to build unconfined apps with the latest clickable version. Otherwise an error is thrown that prevents building the app.
